### PR TITLE
The ApplicationStatus.Result field should be lowercase in JSON

### DIFF
--- a/pkg/apis/fiaas.schibsted.io/v1/types.go
+++ b/pkg/apis/fiaas.schibsted.io/v1/types.go
@@ -95,7 +95,7 @@ type ApplicationStatus struct {
 	metav1.TypeMeta   `json:",inline"` // apiVersion, kind
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 	Logs              []string `json:"logs"`
-	Result            string   `json:"Result"`
+	Result            string   `json:"result"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object


### PR DESCRIPTION
It's currently not possible to access the result value since we're trying to access a `Result` json key instead of a `result` json key. Thus, the `ApplicationStatus.Result` field will always be empty (unless we annotate it properly).

Note: This change doesn't invoke any changes in autogenerated code.