### PR TITLE
use v0.18.0 of client-go and apimachinery

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -14,7 +14,7 @@ blocks:
           - export "PATH=$HOME/bin:$(go env GOPATH)/bin:${PATH}"
           - export "GO111MODULE=on"
           - mkdir -vp "${SEMAPHORE_GIT_DIR}" "$(go env GOPATH)/bin"
-          - sem-version go 1.12
+          - sem-version go 1.13
       jobs:
         - name: verify
           commands:

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -3,6 +3,7 @@
 package e2e
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -83,6 +84,7 @@ func TestApplication(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to create client: %s", err)
 	}
+	ctx := context.Background()
 	for i, testcase := range applicationTests {
 		t.Run(fmt.Sprintf("%d/%s", i, testcase.expectedYamlFilePath), func(t *testing.T) {
 			expected, err := applicationFromYaml(testcase.expectedYamlFilePath)
@@ -91,18 +93,18 @@ func TestApplication(t *testing.T) {
 			}
 
 			applicationsClient := clientset.FiaasV1().Applications(testcase.application.Namespace)
-			_, err = applicationsClient.Create(&testcase.application)
+			_, err = applicationsClient.Create(ctx, &testcase.application, metav1.CreateOptions{})
 			if err != nil {
 				t.Fatalf("failed to create application: %s", err)
 			}
 
 			defer func() {
-				err := applicationsClient.Delete(testcase.application.Name, &metav1.DeleteOptions{})
+				err := applicationsClient.Delete(ctx, testcase.application.Name, metav1.DeleteOptions{})
 				if err != nil && !apimachineryerrors.IsNotFound(err) {
 					t.Fatalf("failed to delete application: %s", err)
 				}
 			}()
-			actual, err := applicationsClient.Get(testcase.application.Name, metav1.GetOptions{})
+			actual, err := applicationsClient.Get(ctx, testcase.application.Name, metav1.GetOptions{})
 			if err != nil {
 				t.Fatalf("failed to get application: %s", err)
 			}
@@ -197,6 +199,7 @@ func TestApplicationStatus(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to create client: %s", err)
 	}
+	ctx := context.Background()
 	for i, testcase := range applicationStatusTests {
 		t.Run(fmt.Sprintf("%d/%s", i, testcase.expectedYamlFilePath), func(t *testing.T) {
 
@@ -208,19 +211,19 @@ func TestApplicationStatus(t *testing.T) {
 			applicationStatusesClient := clientset.FiaasV1().ApplicationStatuses(
 				testcase.applicationStatus.Namespace)
 			defer func() {
-				err := applicationStatusesClient.Delete(testcase.applicationStatus.Name,
-					&metav1.DeleteOptions{})
+				err := applicationStatusesClient.Delete(ctx, testcase.applicationStatus.Name,
+					metav1.DeleteOptions{})
 				if err != nil && !apimachineryerrors.IsNotFound(err) {
 					t.Fatalf("failed to delete applicationStatus: %s", err)
 				}
 			}()
 
-			_, err = applicationStatusesClient.Create(&testcase.applicationStatus)
+			_, err = applicationStatusesClient.Create(ctx, &testcase.applicationStatus, metav1.CreateOptions{})
 			if err != nil {
 				t.Fatalf("failed to create applicationStatus: %s", err)
 			}
 
-			actual, err := applicationStatusesClient.Get(testcase.applicationStatus.Name,
+			actual, err := applicationStatusesClient.Get(ctx, testcase.applicationStatus.Name,
 				metav1.GetOptions{})
 			if err != nil {
 				t.Fatalf("failed to get applicationStatus: %s", err)

--- a/go.mod
+++ b/go.mod
@@ -3,28 +3,8 @@ module github.com/fiaas/fiaas-go-client
 go 1.12
 
 require (
-	github.com/evanphx/json-patch v4.2.0+incompatible // indirect
 	github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680
-	github.com/gogo/protobuf v1.2.2-0.20190723190241-65acae22fc9d // indirect
-	github.com/golang/protobuf v1.3.1 // indirect
-	github.com/hashicorp/golang-lru v0.5.1 // indirect
-	github.com/json-iterator/go v1.1.7 // indirect
-	github.com/kr/pretty v0.1.0 // indirect
-	github.com/onsi/ginkgo v1.8.0 // indirect
-	github.com/onsi/gomega v1.5.0 // indirect
-	github.com/spf13/pflag v1.0.3 // indirect
-	github.com/stretchr/testify v1.3.0
-	golang.org/x/crypto v0.0.0-20190911031432-227b76d455e7 // indirect
-	golang.org/x/net v0.0.0-20190812203447-cdfb69ac37fc // indirect
-	golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45 // indirect
-	golang.org/x/sys v0.0.0-20190616124812-15dcb6c0061f // indirect
-	golang.org/x/text v0.3.2 // indirect
-	golang.org/x/time v0.0.0-20190308202827-9d24e82272b4 // indirect
-	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 // indirect
-	gopkg.in/yaml.v2 v2.2.2
-	k8s.io/apimachinery v0.0.0-20190612205821-1799e75a0719
-	k8s.io/client-go v0.0.0-20190620085101-78d2af792bab
-	k8s.io/klog v1.0.0 // indirect
-	k8s.io/kube-openapi v0.0.0-20190816220812-743ec37842bf // indirect
-	k8s.io/utils v0.0.0-20190907131718-3d4f5b7dea0b // indirect
+	github.com/stretchr/testify v1.4.0
+	k8s.io/apimachinery v0.18.0
+	k8s.io/client-go v0.18.0
 )

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/fiaas/fiaas-go-client
 
-go 1.12
+go 1.13
 
 require (
 	github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680

--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -8,7 +8,7 @@ TEMP_DIR=`mktemp -d`
 SCRIPT_ROOT=$(dirname ${BASH_SOURCE})/..
 CODEGEN_PACKAGE=$TEMP_DIR/code-generator
 
-git clone -b kubernetes-1.15.0 https://github.com/kubernetes/code-generator $CODEGEN_PACKAGE
+git clone -b kubernetes-1.18.0 https://github.com/kubernetes/code-generator $CODEGEN_PACKAGE
 
 export GO111MODULE=on
 

--- a/pkg/client/clientset/versioned/clientset.go
+++ b/pkg/client/clientset/versioned/clientset.go
@@ -3,6 +3,8 @@
 package versioned
 
 import (
+	"fmt"
+
 	fiaasv1 "github.com/fiaas/fiaas-go-client/pkg/client/clientset/versioned/typed/fiaas.schibsted.io/v1"
 	discovery "k8s.io/client-go/discovery"
 	rest "k8s.io/client-go/rest"
@@ -35,9 +37,14 @@ func (c *Clientset) Discovery() discovery.DiscoveryInterface {
 }
 
 // NewForConfig creates a new Clientset for the given config.
+// If config's RateLimiter is not set and QPS and Burst are acceptable,
+// NewForConfig will generate a rate-limiter in configShallowCopy.
 func NewForConfig(c *rest.Config) (*Clientset, error) {
 	configShallowCopy := *c
 	if configShallowCopy.RateLimiter == nil && configShallowCopy.QPS > 0 {
+		if configShallowCopy.Burst <= 0 {
+			return nil, fmt.Errorf("burst is required to be greater than 0 when RateLimiter is not set and QPS is set to greater than 0")
+		}
 		configShallowCopy.RateLimiter = flowcontrol.NewTokenBucketRateLimiter(configShallowCopy.QPS, configShallowCopy.Burst)
 	}
 	var cs Clientset

--- a/pkg/client/clientset/versioned/typed/fiaas.schibsted.io/v1/application.go
+++ b/pkg/client/clientset/versioned/typed/fiaas.schibsted.io/v1/application.go
@@ -3,6 +3,7 @@
 package v1
 
 import (
+	"context"
 	"time"
 
 	v1 "github.com/fiaas/fiaas-go-client/pkg/apis/fiaas.schibsted.io/v1"
@@ -21,14 +22,14 @@ type ApplicationsGetter interface {
 
 // ApplicationInterface has methods to work with Application resources.
 type ApplicationInterface interface {
-	Create(*v1.Application) (*v1.Application, error)
-	Update(*v1.Application) (*v1.Application, error)
-	Delete(name string, options *metav1.DeleteOptions) error
-	DeleteCollection(options *metav1.DeleteOptions, listOptions metav1.ListOptions) error
-	Get(name string, options metav1.GetOptions) (*v1.Application, error)
-	List(opts metav1.ListOptions) (*v1.ApplicationList, error)
-	Watch(opts metav1.ListOptions) (watch.Interface, error)
-	Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1.Application, err error)
+	Create(ctx context.Context, application *v1.Application, opts metav1.CreateOptions) (*v1.Application, error)
+	Update(ctx context.Context, application *v1.Application, opts metav1.UpdateOptions) (*v1.Application, error)
+	Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error
+	DeleteCollection(ctx context.Context, opts metav1.DeleteOptions, listOpts metav1.ListOptions) error
+	Get(ctx context.Context, name string, opts metav1.GetOptions) (*v1.Application, error)
+	List(ctx context.Context, opts metav1.ListOptions) (*v1.ApplicationList, error)
+	Watch(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error)
+	Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions, subresources ...string) (result *v1.Application, err error)
 	ApplicationExpansion
 }
 
@@ -47,20 +48,20 @@ func newApplications(c *FiaasV1Client, namespace string) *applications {
 }
 
 // Get takes name of the application, and returns the corresponding application object, and an error if there is any.
-func (c *applications) Get(name string, options metav1.GetOptions) (result *v1.Application, err error) {
+func (c *applications) Get(ctx context.Context, name string, options metav1.GetOptions) (result *v1.Application, err error) {
 	result = &v1.Application{}
 	err = c.client.Get().
 		Namespace(c.ns).
 		Resource("applications").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
+		Do(ctx).
 		Into(result)
 	return
 }
 
 // List takes label and field selectors, and returns the list of Applications that match those selectors.
-func (c *applications) List(opts metav1.ListOptions) (result *v1.ApplicationList, err error) {
+func (c *applications) List(ctx context.Context, opts metav1.ListOptions) (result *v1.ApplicationList, err error) {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second
@@ -71,13 +72,13 @@ func (c *applications) List(opts metav1.ListOptions) (result *v1.ApplicationList
 		Resource("applications").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Do().
+		Do(ctx).
 		Into(result)
 	return
 }
 
 // Watch returns a watch.Interface that watches the requested applications.
-func (c *applications) Watch(opts metav1.ListOptions) (watch.Interface, error) {
+func (c *applications) Watch(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error) {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second
@@ -88,71 +89,74 @@ func (c *applications) Watch(opts metav1.ListOptions) (watch.Interface, error) {
 		Resource("applications").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Watch()
+		Watch(ctx)
 }
 
 // Create takes the representation of a application and creates it.  Returns the server's representation of the application, and an error, if there is any.
-func (c *applications) Create(application *v1.Application) (result *v1.Application, err error) {
+func (c *applications) Create(ctx context.Context, application *v1.Application, opts metav1.CreateOptions) (result *v1.Application, err error) {
 	result = &v1.Application{}
 	err = c.client.Post().
 		Namespace(c.ns).
 		Resource("applications").
+		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(application).
-		Do().
+		Do(ctx).
 		Into(result)
 	return
 }
 
 // Update takes the representation of a application and updates it. Returns the server's representation of the application, and an error, if there is any.
-func (c *applications) Update(application *v1.Application) (result *v1.Application, err error) {
+func (c *applications) Update(ctx context.Context, application *v1.Application, opts metav1.UpdateOptions) (result *v1.Application, err error) {
 	result = &v1.Application{}
 	err = c.client.Put().
 		Namespace(c.ns).
 		Resource("applications").
 		Name(application.Name).
+		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(application).
-		Do().
+		Do(ctx).
 		Into(result)
 	return
 }
 
 // Delete takes name of the application and deletes it. Returns an error if one occurs.
-func (c *applications) Delete(name string, options *metav1.DeleteOptions) error {
+func (c *applications) Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error {
 	return c.client.Delete().
 		Namespace(c.ns).
 		Resource("applications").
 		Name(name).
-		Body(options).
-		Do().
+		Body(&opts).
+		Do(ctx).
 		Error()
 }
 
 // DeleteCollection deletes a collection of objects.
-func (c *applications) DeleteCollection(options *metav1.DeleteOptions, listOptions metav1.ListOptions) error {
+func (c *applications) DeleteCollection(ctx context.Context, opts metav1.DeleteOptions, listOpts metav1.ListOptions) error {
 	var timeout time.Duration
-	if listOptions.TimeoutSeconds != nil {
-		timeout = time.Duration(*listOptions.TimeoutSeconds) * time.Second
+	if listOpts.TimeoutSeconds != nil {
+		timeout = time.Duration(*listOpts.TimeoutSeconds) * time.Second
 	}
 	return c.client.Delete().
 		Namespace(c.ns).
 		Resource("applications").
-		VersionedParams(&listOptions, scheme.ParameterCodec).
+		VersionedParams(&listOpts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Body(options).
-		Do().
+		Body(&opts).
+		Do(ctx).
 		Error()
 }
 
 // Patch applies the patch and returns the patched application.
-func (c *applications) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1.Application, err error) {
+func (c *applications) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions, subresources ...string) (result *v1.Application, err error) {
 	result = &v1.Application{}
 	err = c.client.Patch(pt).
 		Namespace(c.ns).
 		Resource("applications").
-		SubResource(subresources...).
 		Name(name).
+		SubResource(subresources...).
+		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(data).
-		Do().
+		Do(ctx).
 		Into(result)
 	return
 }

--- a/pkg/client/clientset/versioned/typed/fiaas.schibsted.io/v1/applicationstatus.go
+++ b/pkg/client/clientset/versioned/typed/fiaas.schibsted.io/v1/applicationstatus.go
@@ -3,6 +3,7 @@
 package v1
 
 import (
+	"context"
 	"time"
 
 	v1 "github.com/fiaas/fiaas-go-client/pkg/apis/fiaas.schibsted.io/v1"
@@ -21,14 +22,14 @@ type ApplicationStatusesGetter interface {
 
 // ApplicationStatusInterface has methods to work with ApplicationStatus resources.
 type ApplicationStatusInterface interface {
-	Create(*v1.ApplicationStatus) (*v1.ApplicationStatus, error)
-	Update(*v1.ApplicationStatus) (*v1.ApplicationStatus, error)
-	Delete(name string, options *metav1.DeleteOptions) error
-	DeleteCollection(options *metav1.DeleteOptions, listOptions metav1.ListOptions) error
-	Get(name string, options metav1.GetOptions) (*v1.ApplicationStatus, error)
-	List(opts metav1.ListOptions) (*v1.ApplicationStatusList, error)
-	Watch(opts metav1.ListOptions) (watch.Interface, error)
-	Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1.ApplicationStatus, err error)
+	Create(ctx context.Context, applicationStatus *v1.ApplicationStatus, opts metav1.CreateOptions) (*v1.ApplicationStatus, error)
+	Update(ctx context.Context, applicationStatus *v1.ApplicationStatus, opts metav1.UpdateOptions) (*v1.ApplicationStatus, error)
+	Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error
+	DeleteCollection(ctx context.Context, opts metav1.DeleteOptions, listOpts metav1.ListOptions) error
+	Get(ctx context.Context, name string, opts metav1.GetOptions) (*v1.ApplicationStatus, error)
+	List(ctx context.Context, opts metav1.ListOptions) (*v1.ApplicationStatusList, error)
+	Watch(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error)
+	Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions, subresources ...string) (result *v1.ApplicationStatus, err error)
 	ApplicationStatusExpansion
 }
 
@@ -47,20 +48,20 @@ func newApplicationStatuses(c *FiaasV1Client, namespace string) *applicationStat
 }
 
 // Get takes name of the applicationStatus, and returns the corresponding applicationStatus object, and an error if there is any.
-func (c *applicationStatuses) Get(name string, options metav1.GetOptions) (result *v1.ApplicationStatus, err error) {
+func (c *applicationStatuses) Get(ctx context.Context, name string, options metav1.GetOptions) (result *v1.ApplicationStatus, err error) {
 	result = &v1.ApplicationStatus{}
 	err = c.client.Get().
 		Namespace(c.ns).
 		Resource("application-statuses").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
+		Do(ctx).
 		Into(result)
 	return
 }
 
 // List takes label and field selectors, and returns the list of ApplicationStatuses that match those selectors.
-func (c *applicationStatuses) List(opts metav1.ListOptions) (result *v1.ApplicationStatusList, err error) {
+func (c *applicationStatuses) List(ctx context.Context, opts metav1.ListOptions) (result *v1.ApplicationStatusList, err error) {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second
@@ -71,13 +72,13 @@ func (c *applicationStatuses) List(opts metav1.ListOptions) (result *v1.Applicat
 		Resource("application-statuses").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Do().
+		Do(ctx).
 		Into(result)
 	return
 }
 
 // Watch returns a watch.Interface that watches the requested applicationStatuses.
-func (c *applicationStatuses) Watch(opts metav1.ListOptions) (watch.Interface, error) {
+func (c *applicationStatuses) Watch(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error) {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second
@@ -88,71 +89,74 @@ func (c *applicationStatuses) Watch(opts metav1.ListOptions) (watch.Interface, e
 		Resource("application-statuses").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Watch()
+		Watch(ctx)
 }
 
 // Create takes the representation of a applicationStatus and creates it.  Returns the server's representation of the applicationStatus, and an error, if there is any.
-func (c *applicationStatuses) Create(applicationStatus *v1.ApplicationStatus) (result *v1.ApplicationStatus, err error) {
+func (c *applicationStatuses) Create(ctx context.Context, applicationStatus *v1.ApplicationStatus, opts metav1.CreateOptions) (result *v1.ApplicationStatus, err error) {
 	result = &v1.ApplicationStatus{}
 	err = c.client.Post().
 		Namespace(c.ns).
 		Resource("application-statuses").
+		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(applicationStatus).
-		Do().
+		Do(ctx).
 		Into(result)
 	return
 }
 
 // Update takes the representation of a applicationStatus and updates it. Returns the server's representation of the applicationStatus, and an error, if there is any.
-func (c *applicationStatuses) Update(applicationStatus *v1.ApplicationStatus) (result *v1.ApplicationStatus, err error) {
+func (c *applicationStatuses) Update(ctx context.Context, applicationStatus *v1.ApplicationStatus, opts metav1.UpdateOptions) (result *v1.ApplicationStatus, err error) {
 	result = &v1.ApplicationStatus{}
 	err = c.client.Put().
 		Namespace(c.ns).
 		Resource("application-statuses").
 		Name(applicationStatus.Name).
+		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(applicationStatus).
-		Do().
+		Do(ctx).
 		Into(result)
 	return
 }
 
 // Delete takes name of the applicationStatus and deletes it. Returns an error if one occurs.
-func (c *applicationStatuses) Delete(name string, options *metav1.DeleteOptions) error {
+func (c *applicationStatuses) Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error {
 	return c.client.Delete().
 		Namespace(c.ns).
 		Resource("application-statuses").
 		Name(name).
-		Body(options).
-		Do().
+		Body(&opts).
+		Do(ctx).
 		Error()
 }
 
 // DeleteCollection deletes a collection of objects.
-func (c *applicationStatuses) DeleteCollection(options *metav1.DeleteOptions, listOptions metav1.ListOptions) error {
+func (c *applicationStatuses) DeleteCollection(ctx context.Context, opts metav1.DeleteOptions, listOpts metav1.ListOptions) error {
 	var timeout time.Duration
-	if listOptions.TimeoutSeconds != nil {
-		timeout = time.Duration(*listOptions.TimeoutSeconds) * time.Second
+	if listOpts.TimeoutSeconds != nil {
+		timeout = time.Duration(*listOpts.TimeoutSeconds) * time.Second
 	}
 	return c.client.Delete().
 		Namespace(c.ns).
 		Resource("application-statuses").
-		VersionedParams(&listOptions, scheme.ParameterCodec).
+		VersionedParams(&listOpts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Body(options).
-		Do().
+		Body(&opts).
+		Do(ctx).
 		Error()
 }
 
 // Patch applies the patch and returns the patched applicationStatus.
-func (c *applicationStatuses) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1.ApplicationStatus, err error) {
+func (c *applicationStatuses) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions, subresources ...string) (result *v1.ApplicationStatus, err error) {
 	result = &v1.ApplicationStatus{}
 	err = c.client.Patch(pt).
 		Namespace(c.ns).
 		Resource("application-statuses").
-		SubResource(subresources...).
 		Name(name).
+		SubResource(subresources...).
+		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(data).
-		Do().
+		Do(ctx).
 		Into(result)
 	return
 }

--- a/pkg/client/clientset/versioned/typed/fiaas.schibsted.io/v1/fake/fake_application.go
+++ b/pkg/client/clientset/versioned/typed/fiaas.schibsted.io/v1/fake/fake_application.go
@@ -3,6 +3,8 @@
 package fake
 
 import (
+	"context"
+
 	fiaasschibstediov1 "github.com/fiaas/fiaas-go-client/pkg/apis/fiaas.schibsted.io/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	labels "k8s.io/apimachinery/pkg/labels"
@@ -23,7 +25,7 @@ var applicationsResource = schema.GroupVersionResource{Group: "fiaas.schibsted.i
 var applicationsKind = schema.GroupVersionKind{Group: "fiaas.schibsted.io", Version: "v1", Kind: "Application"}
 
 // Get takes name of the application, and returns the corresponding application object, and an error if there is any.
-func (c *FakeApplications) Get(name string, options v1.GetOptions) (result *fiaasschibstediov1.Application, err error) {
+func (c *FakeApplications) Get(ctx context.Context, name string, options v1.GetOptions) (result *fiaasschibstediov1.Application, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewGetAction(applicationsResource, c.ns, name), &fiaasschibstediov1.Application{})
 
@@ -34,7 +36,7 @@ func (c *FakeApplications) Get(name string, options v1.GetOptions) (result *fiaa
 }
 
 // List takes label and field selectors, and returns the list of Applications that match those selectors.
-func (c *FakeApplications) List(opts v1.ListOptions) (result *fiaasschibstediov1.ApplicationList, err error) {
+func (c *FakeApplications) List(ctx context.Context, opts v1.ListOptions) (result *fiaasschibstediov1.ApplicationList, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewListAction(applicationsResource, applicationsKind, c.ns, opts), &fiaasschibstediov1.ApplicationList{})
 
@@ -56,14 +58,14 @@ func (c *FakeApplications) List(opts v1.ListOptions) (result *fiaasschibstediov1
 }
 
 // Watch returns a watch.Interface that watches the requested applications.
-func (c *FakeApplications) Watch(opts v1.ListOptions) (watch.Interface, error) {
+func (c *FakeApplications) Watch(ctx context.Context, opts v1.ListOptions) (watch.Interface, error) {
 	return c.Fake.
 		InvokesWatch(testing.NewWatchAction(applicationsResource, c.ns, opts))
 
 }
 
 // Create takes the representation of a application and creates it.  Returns the server's representation of the application, and an error, if there is any.
-func (c *FakeApplications) Create(application *fiaasschibstediov1.Application) (result *fiaasschibstediov1.Application, err error) {
+func (c *FakeApplications) Create(ctx context.Context, application *fiaasschibstediov1.Application, opts v1.CreateOptions) (result *fiaasschibstediov1.Application, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewCreateAction(applicationsResource, c.ns, application), &fiaasschibstediov1.Application{})
 
@@ -74,7 +76,7 @@ func (c *FakeApplications) Create(application *fiaasschibstediov1.Application) (
 }
 
 // Update takes the representation of a application and updates it. Returns the server's representation of the application, and an error, if there is any.
-func (c *FakeApplications) Update(application *fiaasschibstediov1.Application) (result *fiaasschibstediov1.Application, err error) {
+func (c *FakeApplications) Update(ctx context.Context, application *fiaasschibstediov1.Application, opts v1.UpdateOptions) (result *fiaasschibstediov1.Application, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewUpdateAction(applicationsResource, c.ns, application), &fiaasschibstediov1.Application{})
 
@@ -85,7 +87,7 @@ func (c *FakeApplications) Update(application *fiaasschibstediov1.Application) (
 }
 
 // Delete takes name of the application and deletes it. Returns an error if one occurs.
-func (c *FakeApplications) Delete(name string, options *v1.DeleteOptions) error {
+func (c *FakeApplications) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	_, err := c.Fake.
 		Invokes(testing.NewDeleteAction(applicationsResource, c.ns, name), &fiaasschibstediov1.Application{})
 
@@ -93,15 +95,15 @@ func (c *FakeApplications) Delete(name string, options *v1.DeleteOptions) error 
 }
 
 // DeleteCollection deletes a collection of objects.
-func (c *FakeApplications) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
-	action := testing.NewDeleteCollectionAction(applicationsResource, c.ns, listOptions)
+func (c *FakeApplications) DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error {
+	action := testing.NewDeleteCollectionAction(applicationsResource, c.ns, listOpts)
 
 	_, err := c.Fake.Invokes(action, &fiaasschibstediov1.ApplicationList{})
 	return err
 }
 
 // Patch applies the patch and returns the patched application.
-func (c *FakeApplications) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *fiaasschibstediov1.Application, err error) {
+func (c *FakeApplications) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts v1.PatchOptions, subresources ...string) (result *fiaasschibstediov1.Application, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewPatchSubresourceAction(applicationsResource, c.ns, name, pt, data, subresources...), &fiaasschibstediov1.Application{})
 

--- a/pkg/client/clientset/versioned/typed/fiaas.schibsted.io/v1/fake/fake_applicationstatus.go
+++ b/pkg/client/clientset/versioned/typed/fiaas.schibsted.io/v1/fake/fake_applicationstatus.go
@@ -3,6 +3,8 @@
 package fake
 
 import (
+	"context"
+
 	fiaasschibstediov1 "github.com/fiaas/fiaas-go-client/pkg/apis/fiaas.schibsted.io/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	labels "k8s.io/apimachinery/pkg/labels"
@@ -23,7 +25,7 @@ var applicationstatusesResource = schema.GroupVersionResource{Group: "fiaas.schi
 var applicationstatusesKind = schema.GroupVersionKind{Group: "fiaas.schibsted.io", Version: "v1", Kind: "ApplicationStatus"}
 
 // Get takes name of the applicationStatus, and returns the corresponding applicationStatus object, and an error if there is any.
-func (c *FakeApplicationStatuses) Get(name string, options v1.GetOptions) (result *fiaasschibstediov1.ApplicationStatus, err error) {
+func (c *FakeApplicationStatuses) Get(ctx context.Context, name string, options v1.GetOptions) (result *fiaasschibstediov1.ApplicationStatus, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewGetAction(applicationstatusesResource, c.ns, name), &fiaasschibstediov1.ApplicationStatus{})
 
@@ -34,7 +36,7 @@ func (c *FakeApplicationStatuses) Get(name string, options v1.GetOptions) (resul
 }
 
 // List takes label and field selectors, and returns the list of ApplicationStatuses that match those selectors.
-func (c *FakeApplicationStatuses) List(opts v1.ListOptions) (result *fiaasschibstediov1.ApplicationStatusList, err error) {
+func (c *FakeApplicationStatuses) List(ctx context.Context, opts v1.ListOptions) (result *fiaasschibstediov1.ApplicationStatusList, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewListAction(applicationstatusesResource, applicationstatusesKind, c.ns, opts), &fiaasschibstediov1.ApplicationStatusList{})
 
@@ -56,14 +58,14 @@ func (c *FakeApplicationStatuses) List(opts v1.ListOptions) (result *fiaasschibs
 }
 
 // Watch returns a watch.Interface that watches the requested applicationStatuses.
-func (c *FakeApplicationStatuses) Watch(opts v1.ListOptions) (watch.Interface, error) {
+func (c *FakeApplicationStatuses) Watch(ctx context.Context, opts v1.ListOptions) (watch.Interface, error) {
 	return c.Fake.
 		InvokesWatch(testing.NewWatchAction(applicationstatusesResource, c.ns, opts))
 
 }
 
 // Create takes the representation of a applicationStatus and creates it.  Returns the server's representation of the applicationStatus, and an error, if there is any.
-func (c *FakeApplicationStatuses) Create(applicationStatus *fiaasschibstediov1.ApplicationStatus) (result *fiaasschibstediov1.ApplicationStatus, err error) {
+func (c *FakeApplicationStatuses) Create(ctx context.Context, applicationStatus *fiaasschibstediov1.ApplicationStatus, opts v1.CreateOptions) (result *fiaasschibstediov1.ApplicationStatus, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewCreateAction(applicationstatusesResource, c.ns, applicationStatus), &fiaasschibstediov1.ApplicationStatus{})
 
@@ -74,7 +76,7 @@ func (c *FakeApplicationStatuses) Create(applicationStatus *fiaasschibstediov1.A
 }
 
 // Update takes the representation of a applicationStatus and updates it. Returns the server's representation of the applicationStatus, and an error, if there is any.
-func (c *FakeApplicationStatuses) Update(applicationStatus *fiaasschibstediov1.ApplicationStatus) (result *fiaasschibstediov1.ApplicationStatus, err error) {
+func (c *FakeApplicationStatuses) Update(ctx context.Context, applicationStatus *fiaasschibstediov1.ApplicationStatus, opts v1.UpdateOptions) (result *fiaasschibstediov1.ApplicationStatus, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewUpdateAction(applicationstatusesResource, c.ns, applicationStatus), &fiaasschibstediov1.ApplicationStatus{})
 
@@ -85,7 +87,7 @@ func (c *FakeApplicationStatuses) Update(applicationStatus *fiaasschibstediov1.A
 }
 
 // Delete takes name of the applicationStatus and deletes it. Returns an error if one occurs.
-func (c *FakeApplicationStatuses) Delete(name string, options *v1.DeleteOptions) error {
+func (c *FakeApplicationStatuses) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	_, err := c.Fake.
 		Invokes(testing.NewDeleteAction(applicationstatusesResource, c.ns, name), &fiaasschibstediov1.ApplicationStatus{})
 
@@ -93,15 +95,15 @@ func (c *FakeApplicationStatuses) Delete(name string, options *v1.DeleteOptions)
 }
 
 // DeleteCollection deletes a collection of objects.
-func (c *FakeApplicationStatuses) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
-	action := testing.NewDeleteCollectionAction(applicationstatusesResource, c.ns, listOptions)
+func (c *FakeApplicationStatuses) DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error {
+	action := testing.NewDeleteCollectionAction(applicationstatusesResource, c.ns, listOpts)
 
 	_, err := c.Fake.Invokes(action, &fiaasschibstediov1.ApplicationStatusList{})
 	return err
 }
 
 // Patch applies the patch and returns the patched applicationStatus.
-func (c *FakeApplicationStatuses) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *fiaasschibstediov1.ApplicationStatus, err error) {
+func (c *FakeApplicationStatuses) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts v1.PatchOptions, subresources ...string) (result *fiaasschibstediov1.ApplicationStatus, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewPatchSubresourceAction(applicationstatusesResource, c.ns, name, pt, data, subresources...), &fiaasschibstediov1.ApplicationStatus{})
 

--- a/pkg/client/informers/externalversions/fiaas.schibsted.io/v1/application.go
+++ b/pkg/client/informers/externalversions/fiaas.schibsted.io/v1/application.go
@@ -3,6 +3,7 @@
 package v1
 
 import (
+	"context"
 	time "time"
 
 	fiaasschibstediov1 "github.com/fiaas/fiaas-go-client/pkg/apis/fiaas.schibsted.io/v1"
@@ -45,13 +46,13 @@ func NewFilteredApplicationInformer(client versioned.Interface, namespace string
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.FiaasV1().Applications(namespace).List(options)
+				return client.FiaasV1().Applications(namespace).List(context.TODO(), options)
 			},
 			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.FiaasV1().Applications(namespace).Watch(options)
+				return client.FiaasV1().Applications(namespace).Watch(context.TODO(), options)
 			},
 		},
 		&fiaasschibstediov1.Application{},

--- a/pkg/client/informers/externalversions/fiaas.schibsted.io/v1/applicationstatus.go
+++ b/pkg/client/informers/externalversions/fiaas.schibsted.io/v1/applicationstatus.go
@@ -3,6 +3,7 @@
 package v1
 
 import (
+	"context"
 	time "time"
 
 	fiaasschibstediov1 "github.com/fiaas/fiaas-go-client/pkg/apis/fiaas.schibsted.io/v1"
@@ -45,13 +46,13 @@ func NewFilteredApplicationStatusInformer(client versioned.Interface, namespace 
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.FiaasV1().ApplicationStatuses(namespace).List(options)
+				return client.FiaasV1().ApplicationStatuses(namespace).List(context.TODO(), options)
 			},
 			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.FiaasV1().ApplicationStatuses(namespace).Watch(options)
+				return client.FiaasV1().ApplicationStatuses(namespace).Watch(context.TODO(), options)
 			},
 		},
 		&fiaasschibstediov1.ApplicationStatus{},


### PR DESCRIPTION
this PR will use a more explicit version of k8s.io/client-go and k8s.io/apimachinery, namely v0.18.0 for both of them. We will also version this change as v0.18.0 to try and stay in sync with the Kubernetes libraries we're dependant on.

The lion's share of the code changes in this PR have been made by the code generators which were already set up, the only thing that changed there was the codegen's version.

This change creates a degree of backward incompatability with previous versions of fiaas-go-client, but it will only require modest changes, for example adding a context.Context to some of the API requests.

In addition, the go.mod has been tidied up, and several previously used imports are no longer needed.