### PR TITLE
add serviceaccount to additionallabelsorannotations model

### DIFF
--- a/pkg/apis/fiaas.schibsted.io/v1/types.go
+++ b/pkg/apis/fiaas.schibsted.io/v1/types.go
@@ -55,6 +55,7 @@ type AdditionalLabelsOrAnnotations struct {
 	HorizontalPodAutoscaler map[string]string `json:"horizontal_pod_autoscaler,omitempty"`
 	Ingress                 map[string]string `json:"ingress,omitempty"`
 	Service                 map[string]string `json:"service,omitempty"`
+	ServiceAccount          map[string]string `json:"service_account,omitempty"`
 	Pod                     map[string]string `json:"pod,omitempty"`
 	Status                  map[string]string `json:"status,omitempty"`
 }
@@ -68,7 +69,6 @@ func (in *Config) DeepCopyInto(out *Config) {
 	enc.Encode(in)
 
 	dec.Decode(&out)
-
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/apis/fiaas.schibsted.io/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/fiaas.schibsted.io/v1/zz_generated.deepcopy.go
@@ -47,6 +47,13 @@ func (in *AdditionalLabelsOrAnnotations) DeepCopyInto(out *AdditionalLabelsOrAnn
 			(*out)[key] = val
 		}
 	}
+	if in.ServiceAccount != nil {
+		in, out := &in.ServiceAccount, &out.ServiceAccount
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	if in.Pod != nil {
 		in, out := &in.Pod, &out.Pod
 		*out = make(map[string]string, len(*in))


### PR DESCRIPTION
ServiceAccount has for some time existed as a field in the additionallabelsorannotations model in fiaas-deploy-daemon. This PR brings fiaas-go-client up to date with that change.